### PR TITLE
コンストラクタにheaderRows(1行目)に対してheaderRowsIndex(0番目)を追加｡デフォルトの引数の変更

### DIFF
--- a/class_sheet.gs
+++ b/class_sheet.gs
@@ -3,16 +3,19 @@
 class Sheet {
 
   /**
-   * シートに関するコンストラクタ
+   * シートに関するコンストラクタ 
    * @constructor
    * @param {SpreadsheetApp.sheet} sheet - 対象となるシート。デフォルト引数は「SpreadsheetApp.getActiveSheet()」
-   * @param {number} numHeaderRows - ヘッダー行の数。デフォルト引数は「1」
+   * @param {number} headerRows - ヘッダー行の数。デフォルト引数は「1」
+   * 
    */
-  constructor(sheet = SpreadsheetApp.getActiveSheet(), numHeaderRows = 1) {
+  constructor(sheet = SpreadsheetApp.getActiveSheet(), headerRows = 1) {
     /** @type {SpreadsheetApp.Sheet} */
     this.sheet = sheet;
     /** @type {SpreadsheetApp.Sheet} */
-    this.numHeaderRows = numHeaderRows;
+    this.headerRows = headerRows;
+    /** @type {SpreadsheetApp.Sheet} */
+    this.headerRowsIndex = headerRows - 1;
   }
 
   /**
@@ -25,12 +28,23 @@ class Sheet {
   }
 
   /**
+   * ヘッダーを取得するメソッド
+   * @param {number} index - ヘッダーズのヘッダーとなるインデックス。デフォルト引数は「0 (1 行目)」
+   * @return {Array.<number|string>} ヘッダー
+   */
+  getHeaders(index = this.headerRowsIndex) {
+    const headerValues = this.getHeaderValues();
+    const headers = headerValues[index];
+    return headers;
+  }
+
+  /**
    * ヘッダー部分を取得するメソッド
    * @return {Array.<Array.<number|string>>} ヘッダー部分
    */
   getHeaderValues() {
     const values = this.getDataRangeValues();
-    const headerValues = values.filter((_, i) => i < this.numHeaderRows);
+    const headerValues = values.filter((_, i) => i < this.headerRows);
     return headerValues;
   }
 
@@ -40,17 +54,17 @@ class Sheet {
    */
   getDataValues() {
     const values = this.getDataRangeValues();
-    const dataValues = values.filter((_, i) => i >= this.numHeaderRows);
+    const dataValues = values.filter((_, i) => i >= this.headerRows);
     return dataValues;
   }
 
   /**
    * ヘッダー情報 (各) から列番号を返すメソッド
    * @param {string} header - ヘッダー
-   * @param {number} index - ヘッダーズのヘッダーとなるインデックス。デフォルト引数は「1 (2 行目)」
+   * @param {number} index - ヘッダーズのヘッダーとなるインデックス。デフォルト引数は「0 (1 行目)」
    * @return {number} 列番号
    */
-  getNumColumnByHeaderName(header, index = 1) {
+  getNumColumnByHeaderName(header, index = this.headerRowsIndex) {
     const columnIndex = this.getColumnIndexByHeaderName(header, index);
     const numColumn = columnIndex + 1;
     return numColumn;
@@ -59,10 +73,10 @@ class Sheet {
   /**
    * ヘッダー情報 (各) から列インデックスを返すメソッド
    * @param {string} header - ヘッダー
-   * @param {number} index - ヘッダーズのヘッダーとなるインデックス。デフォルト引数は「1 (2 行目)」
+   * @param {number} index - ヘッダーズのヘッダーとなるインデックス。デフォルト引数は「0 (1 行目)」
    * @return {number} 列インデックス
    */
-  getColumnIndexByHeaderName(header, index = 1) {
+  getColumnIndexByHeaderName(header, index = this.headerRowsIndex) {
     const headers = this.getHeaders(index);
     const columnIndex = headers.indexOf(header);
     return columnIndex;
@@ -75,7 +89,7 @@ class Sheet {
   setValuesHeaderRowAfter(values) {
     this.clearDataValues();
     if (!values.length) return;
-    this.sheet.getRange(this.numHeaderRows + 1, 1, values.length, values[0].length).
+    this.sheet.getRange(this.headerRows + 1, 1, values.length, values[0].length).
       setValues(values);
   }
 
@@ -86,7 +100,7 @@ class Sheet {
     const values = this.getDataValues();
     if (!values.length) return;
     this.sheet.
-      getRange(1 + this.numHeaderRows, 1, this.sheet.getLastRow() - this.numHeaderRows, this.sheet.getLastColumn()).
+      getRange(1 + this.headerRows, 1, this.sheet.getLastRow() - this.headerRows, this.sheet.getLastColumn()).
       clearContent();
   }
 
@@ -108,7 +122,7 @@ class Sheet {
    */
   sortDataRows(column = 1, ascending = true) {
     this.sheet.
-      getRange(this.numHeaderRows + 1, 1, this.sheet.getLastRow() - this.numHeaderRows, this.sheet.getLastColumn()).
+      getRange(this.headerRows + 1, 1, this.sheet.getLastRow() - this.headerRows, this.sheet.getLastColumn()).
       sort({ column: column, ascending: ascending });
   }
 
@@ -125,7 +139,7 @@ class Sheet {
     return values;
   }
 
-  /**
+  /** TODO: record と row (or rowIndex) を dict 型に持たせたい
     * シートの値から、ヘッダー情報をプロパティとして持つ Map 型を生成するメソッド
     * @return {Array.<Map>} ヘッダー情報を key, 値を value として持つ Map
     */


### PR DESCRIPTION
プレビューだとたくさん変わっているように見えるけど･･･｡
変更点と変更の経緯です｡

下記のメソッドのデフォルト引数のindexが定数だと使いにくい
```
getNumColumnByHeaderName(header, index = 1)
getColumnIndexByHeaderName(header, index = 1)
```

なのでコンストラクタにheaderRowsIndexを追加
```
    /** @type {SpreadsheetApp.Sheet} */
    this.headerRowsIndex = headerRows - 1;
```

合わせて､デフォルト引数を変更したいです｡
```
getNumColumnByHeaderName(header, index = this.headerRowsIndex)
getColumnIndexByHeaderName(header, index = this.headerRowsIndex)
```
こうすると､だいたいの場合､indexを指定せずに､使用できて楽になるはず!
